### PR TITLE
Parallel reduce

### DIFF
--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -1,0 +1,121 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_HIP_BLOCKSIZE_DEDUCTION_HPP
+#define KOKKOS_HIP_BLOCKSIZE_DEDUCTION_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#if defined(KOKKOS_ENABLE_HIP) && defined(__HIPCC__)
+
+#include <HIP/Kokkos_HIP_Instance.hpp>
+#include <HIP/Kokkos_HIP_KernelLaunch.hpp>
+
+namespace Kokkos {
+namespace Experimental {
+namespace Impl {
+template <typename DriverType, typename LaunchBounds, bool Large>
+struct HIPGetMaxBlockSize;
+
+template <typename DriverType, typename LaunchBounds>
+int hip_get_max_block_size(typename DriverType::functor_type const &f,
+                           size_t const vector_length,
+                           size_t const shmem_extra_block,
+                           size_t const shmem_extra_thread) {
+  return HIPGetMaxBlockSize<DriverType, LaunchBounds, true>::get_block_size(
+      f, vector_length, shmem_extra_block, shmem_extra_thread);
+}
+
+template <typename DriverType>
+struct HIPGetMaxBlockSize<DriverType, Kokkos::LaunchBounds<>, true> {
+  static int get_block_size(typename DriverType::functor_type const &f,
+                            size_t const vector_length,
+                            size_t const shmem_extra_block,
+                            size_t const shmem_extra_thread) {
+    unsigned int numBlocks = 0;
+    int blockSize          = 1024;
+    int sharedmem =
+        shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
+        ::Kokkos::Impl::FunctorTeamShmemSize<
+            typename DriverType::functor_type>::value(f, blockSize /
+                                                             vector_length);
+    hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &numBlocks, hip_parallel_launch_constant_memory<DriverType>, blockSize,
+        sharedmem);
+
+    if (numBlocks > 0) return blockSize;
+    while (blockSize > HIPTraits::WarpSize && numBlocks == 0) {
+      blockSize /= 2;
+      sharedmem =
+          shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
+          ::Kokkos::Impl::FunctorTeamShmemSize<
+              typename DriverType::functor_type>::value(f, blockSize /
+                                                               vector_length);
+
+      hipOccupancyMaxActiveBlocksPerMultiprocessor(
+          &numBlocks, hip_parallel_launch_constant_memory<DriverType>,
+          blockSize, sharedmem);
+    }
+    int blockSizeUpperBound = blockSize * 2;
+    while (blockSize < blockSizeUpperBound && numBlocks > 0) {
+      blockSize += HIPTraits::WarpSize;
+      sharedmem =
+          shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
+          ::Kokkos::Impl::FunctorTeamShmemSize<
+              typename DriverType::functor_type>::value(f, blockSize /
+                                                               vector_length);
+
+      hipOccupancyMaxActiveBlocksPerMultiprocessor(
+          &numBlocks, hip_parallel_launch_constant_memory<DriverType>,
+          blockSize, sharedmem);
+    }
+    return blockSize - HIPTraits::WarpSize;
+  }
+};
+}  // namespace Impl
+}  // namespace Experimental
+}  // namespace Kokkos
+
+#endif
+
+#endif

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -48,7 +48,9 @@
 
 #if defined(KOKKOS_ENABLE_HIP) && defined(__HIPCC__)
 
+#include <HIP/Kokkos_HIP_BlockSize_Deduction.hpp>
 #include <HIP/Kokkos_HIP_KernelLaunch.hpp>
+#include <HIP/Kokkos_HIP_ReduceScan.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -68,7 +70,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
   const Policy m_policy;
 
   ParallelFor()        = delete;
-  ParallelFor &operator=(const ParallelFor &) = delete;
+  ParallelFor& operator=(const ParallelFor&) = delete;
 
   template <class TagType>
   inline __device__
@@ -113,10 +115,246 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
         false);
   }
 
-  ParallelFor(const FunctorType &arg_functor, const Policy &arg_policy)
+  ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
       : m_functor(arg_functor), m_policy(arg_policy) {}
 };
 
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+template <class FunctorType, class ReducerType, class... Traits>
+class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
+                     Kokkos::Experimental::HIP> {
+ public:
+  using Policy = Kokkos::RangePolicy<Traits...>;
+
+ private:
+  using WorkRange    = typename Policy::WorkRange;
+  using WorkTag      = typename Policy::work_tag;
+  using Member       = typename Policy::member_type;
+  using LaunchBounds = typename Policy::launch_bounds;
+
+  using ReducerConditional =
+      Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
+                         FunctorType, ReducerType>;
+  using ReducerTypeFwd = typename ReducerConditional::type;
+  using WorkTagFwd =
+      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
+                                  WorkTag, void>::type;
+
+  using ValueTraits =
+      Kokkos::Impl::FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>;
+  using ValueInit = Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
+  using ValueJoin = Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd>;
+
+ public:
+  using pointer_type   = typename ValueTraits::pointer_type;
+  using value_type     = typename ValueTraits::value_type;
+  using reference_type = typename ValueTraits::reference_type;
+  using functor_type   = FunctorType;
+  using size_type      = Kokkos::Experimental::HIP::size_type;
+  using index_type     = typename Policy::index_type;
+
+  // Algorithmic constraints: blockSize is a power of two AND hipBlockDim_y ==
+  // hipBlockDim_z == 1
+
+  const FunctorType m_functor;
+  const Policy m_policy;
+  const ReducerType m_reducer;
+  const pointer_type m_result_ptr;
+  const bool m_result_ptr_device_accessible;
+  size_type* m_scratch_space;
+  size_type* m_scratch_flags;
+
+  // Shall we use the shfl based reduction or not (only use it for static sized
+  // types of more than 128bit)
+  enum {
+    UseShflReduction = false
+  };  //((sizeof(value_type)>2*sizeof(double)) && ValueTraits::StaticValueSize)
+      //};
+      // Some crutch to do function overloading
+ private:
+  using DummyShflReductionType  = double;
+  using DummySHMEMReductionType = int;
+
+ public:
+  // Make the exec_range calls call to Reduce::DeviceIterateTile
+  template <class TagType>
+  __device__ inline
+      typename std::enable_if<std::is_same<TagType, void>::value>::type
+      exec_range(const Member& i, reference_type update) const {
+    m_functor(i, update);
+  }
+
+  template <class TagType>
+  __device__ inline
+      typename std::enable_if<!std::is_same<TagType, void>::value>::type
+      exec_range(const Member& i, reference_type update) const {
+    m_functor(TagType(), i, update);
+  }
+
+  __device__ inline void operator()() const {
+    const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
+                                                   sizeof(size_type)>
+        word_count(ValueTraits::value_size(
+                       ReducerConditional::select(m_functor, m_reducer)) /
+                   sizeof(size_type));
+
+    {
+      reference_type value = ValueInit::init(
+          ReducerConditional::select(m_functor, m_reducer),
+          ::Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>() +
+              hipThreadIdx_y * word_count.value);
+
+      // Number of blocks is bounded so that the reduction can be limited to two
+      // passes. Each thread block is given an approximately equal amount of
+      // work to perform. Accumulate the values for this block. The accumulation
+      // ordering does not match the final pass, but is arithmetically
+      // equivalent.
+
+      const WorkRange range(m_policy, hipBlockIdx_x, hipGridDim_x);
+
+      for (Member iwork     = range.begin() + hipThreadIdx_y,
+                  iwork_end = range.end();
+           iwork < iwork_end; iwork += hipBlockDim_y) {
+        this->template exec_range<WorkTag>(iwork, value);
+      }
+    }
+
+    // Reduce with final value at hipblockDim_y - 1 location.
+    if (hip_single_inter_block_reduce_scan<false, ReducerTypeFwd, WorkTagFwd>(
+            ReducerConditional::select(m_functor, m_reducer), hipBlockIdx_x,
+            hipGridDim_x,
+            ::Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>(),
+            m_scratch_space, m_scratch_flags)) {
+      // This is the final block with the final result at the final threads'
+      // location
+
+      size_type* const shared =
+          ::Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>() +
+          (hipBlockDim_y - 1) * word_count.value;
+      size_type* const global = m_result_ptr_device_accessible
+                                    ? reinterpret_cast<size_type*>(m_result_ptr)
+                                    : m_scratch_space;
+
+      if (hipThreadIdx_y == 0) {
+        Kokkos::Impl::FunctorFinal<ReducerTypeFwd, WorkTagFwd>::final(
+            ReducerConditional::select(m_functor, m_reducer), shared);
+      }
+
+      if (::Kokkos::Experimental::Impl::HIPTraits::WarpSize <
+          word_count.value) {
+        __syncthreads();
+      }
+
+      for (unsigned i = hipThreadIdx_y; i < word_count.value;
+           i += hipBlockDim_y) {
+        global[i] = shared[i];
+      }
+    }
+  }
+
+  // Determine block size constrained by shared memory:
+  inline unsigned local_block_size(const FunctorType& f) {
+    // TODO I don't know where 8 comes from
+    unsigned int n = ::Kokkos::Experimental::Impl::HIPTraits::WarpSize * 8;
+    int shmem_size =
+        hip_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag>(
+            f, n);
+    while (
+        (n &&
+         (m_policy.space().impl_internal_space_instance()->m_maxShmemPerBlock <
+          shmem_size)) ||
+        (n > static_cast<unsigned int>(
+                 Kokkos::Experimental::Impl::hip_get_max_block_size<
+                     ParallelReduce, LaunchBounds>(f, 1, shmem_size, 0)))) {
+      n >>= 1;
+      shmem_size =
+          hip_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag>(
+              f, n);
+    }
+    return n;
+  }
+
+  inline void execute() {
+    const index_type nwork = m_policy.end() - m_policy.begin();
+    if (nwork) {
+      const int block_size = local_block_size(m_functor);
+
+      m_scratch_space =
+          ::Kokkos::Experimental::Impl::hip_internal_scratch_space(
+              ValueTraits::value_size(
+                  ReducerConditional::select(m_functor, m_reducer)) *
+              block_size /* block_size == max block_count */);
+      m_scratch_flags =
+          ::Kokkos::Experimental::Impl::hip_internal_scratch_flags(
+              sizeof(size_type));
+
+      // REQUIRED ( 1 , N , 1 )
+      const dim3 block(1, block_size, 1);
+      // Required grid.x <= block.y
+      const dim3 grid(
+          std::min(int(block.y), int((nwork + block.y - 1) / block.y)), 1, 1);
+
+      const int shmem =
+          UseShflReduction
+              ? 0
+              : hip_single_inter_block_reduce_scan_shmem<false, FunctorType,
+                                                         WorkTag>(m_functor,
+                                                                  block.y);
+
+      Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelReduce,
+                                                    LaunchBounds>(
+          *this, grid, block, shmem,
+          m_policy.space().impl_internal_space_instance(),
+          false);  // copy to device and execute
+
+      if (!m_result_ptr_device_accessible) {
+        ::Kokkos::Experimental::HIP().fence();
+
+        if (m_result_ptr) {
+          const int size = ValueTraits::value_size(
+              ReducerConditional::select(m_functor, m_reducer));
+          DeepCopy<HostSpace, ::Kokkos::Experimental::HIPSpace>(
+              m_result_ptr, m_scratch_space, size);
+        }
+      }
+    } else {
+      if (m_result_ptr) {
+        ValueInit::init(ReducerConditional::select(m_functor, m_reducer),
+                        m_result_ptr);
+      }
+    }
+  }
+
+  template <class ViewType>
+  ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
+                 const ViewType& arg_result,
+                 typename std::enable_if<Kokkos::is_view<ViewType>::value,
+                                         void*>::type = NULL)
+      : m_functor(arg_functor),
+        m_policy(arg_policy),
+        m_reducer(InvalidType()),
+        m_result_ptr(arg_result.data()),
+        m_result_ptr_device_accessible(
+            MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
+                              typename ViewType::memory_space>::accessible),
+        m_scratch_space(0),
+        m_scratch_flags(0) {}
+
+  ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
+                 const ReducerType& reducer)
+      : m_functor(arg_functor),
+        m_policy(arg_policy),
+        m_reducer(reducer),
+        m_result_ptr(reducer.view().data()),
+        m_result_ptr_device_accessible(
+            MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
+                              typename ReducerType::result_view_type::
+                                  memory_space>::accessible),
+        m_scratch_space(0),
+        m_scratch_flags(0) {}
+};
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -1,0 +1,209 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_HIP_REDUCESCAN_HPP
+#define KOKKOS_HIP_REDUCESCAN_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#if defined(KOKKOS_ENABLE_HIP) && defined(__HIPCC__)
+
+namespace Kokkos {
+namespace Impl {
+template <class FunctorType, class ArgTag, bool DoScan, bool UseShfl>
+struct HIPReductionsFunctor;
+
+template <typename FunctorType, typename ArgTag>
+struct HIPReductionsFunctor<FunctorType, ArgTag, false, false> {
+  using ValueTraits  = FunctorValueTraits<FunctorType, ArgTag>;
+  using ValueJoin    = FunctorValueJoin<FunctorType, ArgTag>;
+  using ValueInit    = FunctorValueInit<FunctorType, ArgTag>;
+  using ValueOps     = FunctorValueOps<FunctorType, ArgTag>;
+  using pointer_type = typename ValueTraits::pointer_type;
+  using Scalar       = typename ValueTraits::value_type;
+
+  __device__ static inline void scalar_intra_warp_reduction(
+      FunctorType const& functor,
+      Scalar* value,           // Contribution
+      bool const skip_vector,  // Skip threads if Kokkos vector lanes are not
+                               // part of the reduction
+      int const width)         // How much of the warp participates
+  {
+    int const lane_id = (hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x) %
+                        ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+    for (int delta = skip_vector ? hipBlockDim_x : 1; delta < width;
+         delta *= 2) {
+      if (lane_id + delta < ::Kokkos::Experimental::Impl::HIPTraits::WarpSize) {
+        ValueJoin::join(functor, value, value + delta);
+      }
+    }
+    *value = *(value - lane_id);
+  }
+
+  __device__ static inline void scalar_intra_block_reduction(
+      FunctorType const& functor, Scalar value, bool const skip, Scalar* result,
+      int const shared_elements, Scalar* shared_team_buffer_element) {
+    int const warp_id = (hipThreadIdx_y * hipBlockDim_x) /
+                        ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+    Scalar* const my_shared_team_buffer_element =
+        shared_team_buffer_element + hipThreadIdx_y * hipBlockDim_x +
+        hipThreadIdx_x;
+    *my_shared_team_buffer_element = value;
+    // Warp Level Reduction, ignoring Kokkos vector entries
+    scalar_intra_warp_reduction(
+        functor, my_shared_team_buffer_element, skip,
+        ::Kokkos::Experimental::Impl::HIPTraits::WarpSize);
+    // Wait for every warp to be done before using one warp to do final cross
+    // warp reduction
+    __syncthreads();
+
+    if (warp_id == 0) {
+      const unsigned int delta =
+          (hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x) *
+          ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+      if (delta < hipBlockDim_x * hipBlockDim_y)
+        *my_shared_team_buffer_element = shared_team_buffer_element[delta];
+      scalar_intra_warp_reduction(
+          functor, my_shared_team_buffer_element, false,
+          hipBlockDim_x * hipBlockDim_y /
+              ::Kokkos::Experimental::Impl::HIPTraits::WarpSize);
+      if (hipThreadIdx_x + hipThreadIdx_y == 0)
+        *result = *shared_team_buffer_element;
+    }
+  }
+
+  __device__ static inline bool scalar_inter_block_reduction(
+      FunctorType const& functor,
+      ::Kokkos::Experimental::HIP::size_type const block_id,
+      ::Kokkos::Experimental::HIP::size_type const block_count,
+      ::Kokkos::Experimental::HIP::size_type* const shared_data,
+      ::Kokkos::Experimental::HIP::size_type* const global_data,
+      ::Kokkos::Experimental::HIP::size_type* const global_flags) {
+    Scalar* const global_team_buffer_element =
+        reinterpret_cast<Scalar*>(global_data);
+    Scalar* const my_global_team_buffer_element =
+        global_team_buffer_element + hipBlockIdx_x;
+    Scalar* shared_team_buffer_elements =
+        reinterpret_cast<Scalar*>(shared_data);
+    Scalar value        = shared_team_buffer_elements[hipThreadIdx_y];
+    int shared_elements = (hipBlockDim_x * hipBlockDim_y) /
+                          ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+    int global_elements = block_count;
+    __syncthreads();
+
+    // Do the scalar reduction inside each block
+    scalar_intra_block_reduction(functor, value, true,
+                                 my_global_team_buffer_element, shared_elements,
+                                 shared_team_buffer_elements);
+    __syncthreads();
+
+    // Use the last block that is done to do the do the reduction across the
+    // block
+    __shared__ unsigned int num_teams_done;
+    if (hipThreadIdx_x + hipThreadIdx_y == 0) {
+      __threadfence();
+      num_teams_done = Kokkos::atomic_fetch_add(global_flags, 1) + 1;
+    }
+    bool is_last_block = false;
+    // TODO HIP does not support syncthreads_or. That's why we need to make
+    // num_teams_done __shared__
+    // if (__syncthreads_or(num_teams_done == hipGridDim_x)) {*/
+    __syncthreads();
+    if (num_teams_done == hipGridDim_x) {
+      is_last_block = true;
+      *global_flags = 0;
+      ValueInit::init(functor, &value);
+      for (int i = hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
+           i < global_elements; i += hipBlockDim_x * hipBlockDim_y) {
+        ValueJoin::join(functor, &value, &global_team_buffer_element[i]);
+      }
+      scalar_intra_block_reduction(
+          functor, value, false,
+          shared_team_buffer_elements + (hipBlockDim_y - 1), shared_elements,
+          shared_team_buffer_elements);
+    }
+
+    return is_last_block;
+  }
+};
+
+template <bool DoScan, typename FunctorType, typename ArgTag>
+__device__ bool hip_single_inter_block_reduce_scan(
+    FunctorType const& functor,
+    ::Kokkos::Experimental::HIP::size_type const block_id,
+    ::Kokkos::Experimental::HIP::size_type const block_count,
+    ::Kokkos::Experimental::HIP::size_type* const shared_data,
+    ::Kokkos::Experimental::HIP::size_type* const global_data,
+    ::Kokkos::Experimental::HIP::size_type* const global_flags) {
+  using ValueTraits = FunctorValueTraits<FunctorType, ArgTag>;
+  if (!DoScan && ValueTraits::StaticValueSize)
+    // TODO For now we don't use shuffle
+    // return Kokkos::Impl::HIPReductionsFunctor<
+    //    FunctorType, ArgTag, false, (ValueTraits::StaticValueSize > 16)>::
+    //    scalar_inter_block_reduction(functor, block_id, block_count,
+    //                                 shared_data, global_data, global_flags);
+    return Kokkos::Impl::HIPReductionsFunctor<
+        FunctorType, ArgTag, false,
+        false>::scalar_inter_block_reduction(functor, block_id, block_count,
+                                             shared_data, global_data,
+                                             global_flags);
+  else {
+    // TODO implement
+    return false;
+  }
+}
+
+// Size in bytes required for inter block reduce or scan
+template <bool DoScan, class FunctorType, class ArgTag>
+inline unsigned hip_single_inter_block_reduce_scan_shmem(
+    const FunctorType& functor, const unsigned BlockSize) {
+  return (BlockSize + 2) *
+         Impl::FunctorValueTraits<FunctorType, ArgTag>::value_size(functor);
+}
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif
+
+#endif

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -269,6 +269,7 @@ endif
 ifeq ($(KOKKOS_INTERNAL_USE_HIP), 1)
 	OBJ_HIP = UnitTestMainInit.o gtest-all.o
 	OBJ_HIP += TestHIP_Init.o
+	OBJ_HIP += TestHIP_Reducers_a.o TestHIP_Reducers_b.o TestHIP_Reducers_c.o TestHIP_Reducers_d.o
 
 	TARGETS += KokkosCore_UnitTest_HIP
 

--- a/core/unit_test/hip/TestHIP_Reducers_a.cpp
+++ b/core/unit_test/hip/TestHIP_Reducers_a.cpp
@@ -1,0 +1,45 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestReducers_a.hpp>

--- a/core/unit_test/hip/TestHIP_Reducers_b.cpp
+++ b/core/unit_test/hip/TestHIP_Reducers_b.cpp
@@ -1,0 +1,45 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestReducers_b.hpp>

--- a/core/unit_test/hip/TestHIP_Reducers_c.cpp
+++ b/core/unit_test/hip/TestHIP_Reducers_c.cpp
@@ -1,0 +1,45 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestReducers_c.hpp>

--- a/core/unit_test/hip/TestHIP_Reducers_d.cpp
+++ b/core/unit_test/hip/TestHIP_Reducers_d.cpp
@@ -1,0 +1,45 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestReducers_d.hpp>


### PR DESCRIPTION
This supports some simple `parallel_reduce` not all of it. In particular all the `Reducers` tests pass but the `Reductions` test segfault. However, since in the development plan, `parallel_reduce` is split in two different items I think this is OK. I know that the current implementation is not complete but it is clearly useful. Like always, the code is essentially the same as the CUDA code but it was adapted for HIP. The CUDA code is using functions that do not exist in HIP so I had to implement workarounds.

I recommend we merge this as-is and clean it up later.