### PR TITLE
MDRange

### DIFF
--- a/core/src/HIP/KokkosExp_HIP_IterateTile.hpp
+++ b/core/src/HIP/KokkosExp_HIP_IterateTile.hpp
@@ -1,0 +1,3295 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_HIP_EXP_ITERATE_TILE_REFACTOR_HPP
+#define KOKKOS_HIP_EXP_ITERATE_TILE_REFACTOR_HPP
+
+#include <Kokkos_Macros.hpp>
+#if defined(__HIPCC__) && defined(KOKKOS_ENABLE_HIP)
+
+#include <iostream>
+#include <algorithm>
+#include <cstdio>
+
+#include <utility>
+
+#if defined(KOKKOS_ENABLE_PROFILING)
+#include <impl/Kokkos_Profiling_Interface.hpp>
+#include <typeinfo>
+#endif
+
+namespace Kokkos {
+namespace Impl {
+
+// ------------------------------------------------------------------ //
+// ParallelFor iteration pattern
+template <int N, typename PolicyType, typename Functor, typename Tag>
+struct DeviceIterateTile;
+
+// Rank 2
+// Specializations for void tag type
+template <typename PolicyType, typename Functor>
+struct DeviceIterateTile<2, PolicyType, Functor, void> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& policy_, const Functor& f_)
+      : m_policy(policy_), m_func(f_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    // LL
+    if (PolicyType::inner_direction == PolicyType::Left) {
+      for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
+           tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+        const index_type offset_1 =
+            tile_id1 * m_policy.m_tile[1] +
+            static_cast<index_type>(hipThreadIdx_y) +
+            static_cast<index_type>(m_policy.m_lower[1]);
+        if (offset_1 < m_policy.m_upper[1] &&
+            static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
+          for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
+               tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+            const index_type offset_0 =
+                tile_id0 * m_policy.m_tile[0] +
+                static_cast<index_type>(hipThreadIdx_x) +
+                static_cast<index_type>(m_policy.m_lower[0]);
+            if (offset_0 < m_policy.m_upper[0] &&
+                static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
+              m_func(offset_0, offset_1);
+            }
+          }
+        }
+      }
+    }
+    // LR
+    else {
+      for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
+           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+        const index_type offset_0 =
+            tile_id0 * m_policy.m_tile[0] +
+            static_cast<index_type>(hipThreadIdx_x) +
+            static_cast<index_type>(m_policy.m_lower[0]);
+        if (offset_0 < m_policy.m_upper[0] &&
+            static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
+          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            const index_type offset_1 =
+                tile_id1 * m_policy.m_tile[1] +
+                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
+              m_func(offset_0, offset_1);
+            }
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+};
+
+// Specializations for tag type
+template <typename PolicyType, typename Functor, typename Tag>
+struct DeviceIterateTile<2, PolicyType, Functor, Tag> {
+  using index_type = typename PolicyType::index_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_)
+      : m_policy(policy_), m_func(f_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (PolicyType::inner_direction == PolicyType::Left) {
+      // Loop over size maxnumblocks until full range covered
+      for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
+           tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+        const index_type offset_1 =
+            tile_id1 * m_policy.m_tile[1] +
+            static_cast<index_type>(hipThreadIdx_y) +
+            static_cast<index_type>(m_policy.m_lower[1]);
+        if (offset_1 < m_policy.m_upper[1] &&
+            static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
+          for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
+               tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+            const index_type offset_0 =
+                tile_id0 * m_policy.m_tile[0] +
+                static_cast<index_type>(hipThreadIdx_x) +
+                static_cast<index_type>(m_policy.m_lower[0]);
+            if (offset_0 < m_policy.m_upper[0] &&
+                static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
+              m_func(Tag(), offset_0, offset_1);
+            }
+          }
+        }
+      }
+    } else {
+      for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
+           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+        const index_type offset_0 =
+            tile_id0 * m_policy.m_tile[0] +
+            static_cast<index_type>(hipThreadIdx_x) +
+            static_cast<index_type>(m_policy.m_lower[0]);
+        if (offset_0 < m_policy.m_upper[0] &&
+            static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
+          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            const index_type offset_1 =
+                tile_id1 * m_policy.m_tile[1] +
+                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
+              m_func(Tag(), offset_0, offset_1);
+            }
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+};
+
+// Rank 3
+// Specializations for void tag type
+template <typename PolicyType, typename Functor>
+struct DeviceIterateTile<3, PolicyType, Functor, void> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& policy_, const Functor& f_)
+      : m_policy(policy_), m_func(f_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    // LL
+    if (PolicyType::inner_direction == PolicyType::Left) {
+      for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_z);
+           tile_id2 < m_policy.m_tile_end[2]; tile_id2 += hipGridDim_z) {
+        const index_type offset_2 =
+            tile_id2 * m_policy.m_tile[2] +
+            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(m_policy.m_lower[2]);
+        if (offset_2 < m_policy.m_upper[2] &&
+            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[2]) {
+          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            const index_type offset_1 =
+                tile_id1 * m_policy.m_tile[1] +
+                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
+              for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
+                   tile_id0 < m_policy.m_tile_end[0];
+                   tile_id0 += hipGridDim_x) {
+                const index_type offset_0 =
+                    tile_id0 * m_policy.m_tile[0] +
+                    static_cast<index_type>(hipThreadIdx_x) +
+                    static_cast<index_type>(m_policy.m_lower[0]);
+                if (offset_0 < m_policy.m_upper[0] &&
+                    static_cast<index_type>(hipThreadIdx_x) <
+                        m_policy.m_tile[0]) {
+                  m_func(offset_0, offset_1, offset_2);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    // LR
+    else {
+      for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
+           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+        const index_type offset_0 =
+            tile_id0 * m_policy.m_tile[0] +
+            static_cast<index_type>(hipThreadIdx_x) +
+            static_cast<index_type>(m_policy.m_lower[0]);
+        if (offset_0 < m_policy.m_upper[0] &&
+            static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
+          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            const index_type offset_1 =
+                tile_id1 * m_policy.m_tile[1] +
+                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
+              for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_z);
+                   tile_id2 < m_policy.m_tile_end[2];
+                   tile_id2 += hipGridDim_z) {
+                const index_type offset_2 =
+                    tile_id2 * m_policy.m_tile[2] +
+                    static_cast<index_type>(hipThreadIdx_z) +
+                    static_cast<index_type>(m_policy.m_lower[2]);
+                if (offset_2 < m_policy.m_upper[2] &&
+                    static_cast<index_type>(hipThreadIdx_z) <
+                        m_policy.m_tile[2]) {
+                  m_func(offset_0, offset_1, offset_2);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+};
+
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename Tag>
+struct DeviceIterateTile<3, PolicyType, Functor, Tag> {
+  using index_type = typename PolicyType::index_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_)
+      : m_policy(policy_), m_func(f_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (PolicyType::inner_direction == PolicyType::Left) {
+      for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_z);
+           tile_id2 < m_policy.m_tile_end[2]; tile_id2 += hipGridDim_z) {
+        const index_type offset_2 =
+            tile_id2 * m_policy.m_tile[2] +
+            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(m_policy.m_lower[2]);
+        if (offset_2 < m_policy.m_upper[2] &&
+            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[2]) {
+          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            const index_type offset_1 =
+                tile_id1 * m_policy.m_tile[1] +
+                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
+              for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
+                   tile_id0 < m_policy.m_tile_end[0];
+                   tile_id0 += hipGridDim_x) {
+                const index_type offset_0 =
+                    tile_id0 * m_policy.m_tile[0] +
+                    static_cast<index_type>(hipThreadIdx_x) +
+                    static_cast<index_type>(m_policy.m_lower[0]);
+                if (offset_0 < m_policy.m_upper[0] &&
+                    static_cast<index_type>(hipThreadIdx_x) <
+                        m_policy.m_tile[0]) {
+                  m_func(Tag(), offset_0, offset_1, offset_2);
+                }
+              }
+            }
+          }
+        }
+      }
+    } else {
+      for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
+           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+        const index_type offset_0 =
+            tile_id0 * m_policy.m_tile[0] +
+            static_cast<index_type>(hipThreadIdx_x) +
+            static_cast<index_type>(m_policy.m_lower[0]);
+        if (offset_0 < m_policy.m_upper[0] &&
+            static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
+          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            const index_type offset_1 =
+                tile_id1 * m_policy.m_tile[1] +
+                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
+              for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_z);
+                   tile_id2 < m_policy.m_tile_end[2];
+                   tile_id2 += hipGridDim_z) {
+                const index_type offset_2 =
+                    tile_id2 * m_policy.m_tile[2] +
+                    static_cast<index_type>(hipThreadIdx_z) +
+                    static_cast<index_type>(m_policy.m_lower[2]);
+                if (offset_2 < m_policy.m_upper[2] &&
+                    static_cast<index_type>(hipThreadIdx_z) <
+                        m_policy.m_tile[2]) {
+                  m_func(Tag(), offset_0, offset_1, offset_2);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+};
+
+// Rank 4
+// Specializations for void tag type
+template <typename PolicyType, typename Functor>
+struct DeviceIterateTile<4, PolicyType, Functor, void> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& policy_, const Functor& f_)
+      : m_policy(policy_), m_func(f_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    // LL
+    if (PolicyType::inner_direction == PolicyType::Left) {
+      const index_type temp0  = m_policy.m_tile_end[0];
+      const index_type temp1  = m_policy.m_tile_end[1];
+      const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl1 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl0)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl0;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+
+      for (index_type tile_id3 = static_cast<index_type>(hipBlockIdx_z);
+           tile_id3 < m_policy.m_tile_end[3]; tile_id3 += hipGridDim_z) {
+        const index_type offset_3 =
+            tile_id3 * m_policy.m_tile[3] +
+            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(m_policy.m_lower[3]);
+        if (offset_3 < m_policy.m_upper[3] &&
+            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[3]) {
+          for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_y);
+               tile_id2 < m_policy.m_tile_end[2]; tile_id2 += hipGridDim_y) {
+            const index_type offset_2 =
+                tile_id2 * m_policy.m_tile[2] +
+                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(m_policy.m_lower[2]);
+            if (offset_2 < m_policy.m_upper[2] &&
+                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[2]) {
+              for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+                   j += numbl1) {
+                const index_type offset_1 =
+                    j * m_policy.m_tile[1] + thr_id1 +
+                    static_cast<index_type>(m_policy.m_lower[1]);
+                if (offset_1 < m_policy.m_upper[1] &&
+                    thr_id1 < m_policy.m_tile[1]) {
+                  for (index_type i = tile_id0; i < m_policy.m_tile_end[0];
+                       i += numbl0) {
+                    const index_type offset_0 =
+                        i * m_policy.m_tile[0] + thr_id0 +
+                        static_cast<index_type>(m_policy.m_lower[0]);
+                    if (offset_0 < m_policy.m_upper[0] &&
+                        thr_id0 < m_policy.m_tile[0]) {
+                      m_func(offset_0, offset_1, offset_2, offset_3);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    // LR
+    else {
+      const index_type temp0  = m_policy.m_tile_end[0];
+      const index_type temp1  = m_policy.m_tile_end[1];
+      const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl0 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl1)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl1;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+
+      for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
+        const index_type offset_0 =
+            i * m_policy.m_tile[0] + thr_id0 +
+            static_cast<index_type>(m_policy.m_lower[0]);
+        if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
+          for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+               j += numbl1) {
+            const index_type offset_1 =
+                j * m_policy.m_tile[1] + thr_id1 +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                thr_id1 < m_policy.m_tile[1]) {
+              for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_y);
+                   tile_id2 < m_policy.m_tile_end[2];
+                   tile_id2 += hipGridDim_y) {
+                const index_type offset_2 =
+                    tile_id2 * m_policy.m_tile[2] +
+                    static_cast<index_type>(hipThreadIdx_y) +
+                    static_cast<index_type>(m_policy.m_lower[2]);
+                if (offset_2 < m_policy.m_upper[2] &&
+                    static_cast<index_type>(hipThreadIdx_y) <
+                        m_policy.m_tile[2]) {
+                  for (index_type tile_id3 =
+                           static_cast<index_type>(hipBlockIdx_z);
+                       tile_id3 < m_policy.m_tile_end[3];
+                       tile_id3 += hipGridDim_z) {
+                    const index_type offset_3 =
+                        tile_id3 * m_policy.m_tile[3] +
+                        static_cast<index_type>(hipThreadIdx_z) +
+                        static_cast<index_type>(m_policy.m_lower[3]);
+                    if (offset_3 < m_policy.m_upper[3] &&
+                        static_cast<index_type>(hipThreadIdx_z) <
+                            m_policy.m_tile[3]) {
+                      m_func(offset_0, offset_1, offset_2, offset_3);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+};
+
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename Tag>
+struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
+  using index_type = typename PolicyType::index_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_)
+      : m_policy(policy_), m_func(f_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (PolicyType::inner_direction == PolicyType::Left) {
+      const index_type temp0  = m_policy.m_tile_end[0];
+      const index_type temp1  = m_policy.m_tile_end[1];
+      const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl1 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl0)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl0;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+
+      for (index_type tile_id3 = static_cast<index_type>(hipBlockIdx_z);
+           tile_id3 < m_policy.m_tile_end[3]; tile_id3 += hipGridDim_z) {
+        const index_type offset_3 =
+            tile_id3 * m_policy.m_tile[3] +
+            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(m_policy.m_lower[3]);
+        if (offset_3 < m_policy.m_upper[3] &&
+            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[3]) {
+          for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_y);
+               tile_id2 < m_policy.m_tile_end[2]; tile_id2 += hipGridDim_y) {
+            const index_type offset_2 =
+                tile_id2 * m_policy.m_tile[2] +
+                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(m_policy.m_lower[2]);
+            if (offset_2 < m_policy.m_upper[2] &&
+                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[2]) {
+              for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+                   j += numbl1) {
+                const index_type offset_1 =
+                    j * m_policy.m_tile[1] + thr_id1 +
+                    static_cast<index_type>(m_policy.m_lower[1]);
+                if (offset_1 < m_policy.m_upper[1] &&
+                    thr_id1 < m_policy.m_tile[1]) {
+                  for (index_type i = tile_id0; i < m_policy.m_tile_end[0];
+                       i += numbl0) {
+                    const index_type offset_0 =
+                        i * m_policy.m_tile[0] + thr_id0 +
+                        static_cast<index_type>(m_policy.m_lower[0]);
+                    if (offset_0 < m_policy.m_upper[0] &&
+                        thr_id0 < m_policy.m_tile[0]) {
+                      m_func(Tag(), offset_0, offset_1, offset_2, offset_3);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    } else {
+      const index_type temp0  = m_policy.m_tile_end[0];
+      const index_type temp1  = m_policy.m_tile_end[1];
+      const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl0 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl1)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl1;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+
+      for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
+        const index_type offset_0 =
+            i * m_policy.m_tile[0] + thr_id0 +
+            static_cast<index_type>(m_policy.m_lower[0]);
+        if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
+          for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+               j += numbl1) {
+            const index_type offset_1 =
+                tile_id1 * m_policy.m_tile[1] + thr_id1 +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                thr_id1 < m_policy.m_tile[1]) {
+              for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_y);
+                   tile_id2 < m_policy.m_tile_end[2];
+                   tile_id2 += hipGridDim_y) {
+                const index_type offset_2 =
+                    tile_id2 * m_policy.m_tile[2] +
+                    static_cast<index_type>(hipThreadIdx_y) +
+                    static_cast<index_type>(m_policy.m_lower[2]);
+                if (offset_2 < m_policy.m_upper[2] &&
+                    static_cast<index_type>(hipThreadIdx_y) <
+                        m_policy.m_tile[2]) {
+                  for (index_type tile_id3 =
+                           static_cast<index_type>(hipBlockIdx_z);
+                       tile_id3 < m_policy.m_tile_end[3];
+                       tile_id3 += hipGridDim_z) {
+                    const index_type offset_3 =
+                        tile_id3 * m_policy.m_tile[3] +
+                        static_cast<index_type>(hipThreadIdx_z) +
+                        static_cast<index_type>(m_policy.m_lower[3]);
+                    if (offset_3 < m_policy.m_upper[3] &&
+                        static_cast<index_type>(hipThreadIdx_z) <
+                            m_policy.m_tile[3]) {
+                      m_func(Tag(), offset_0, offset_1, offset_2, offset_3);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+};
+
+// Rank 5
+// Specializations for void tag type
+template <typename PolicyType, typename Functor>
+struct DeviceIterateTile<5, PolicyType, Functor, void> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& policy_, const Functor& f_)
+      : m_policy(policy_), m_func(f_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    // LL
+    if (PolicyType::inner_direction == PolicyType::Left) {
+      index_type temp0        = m_policy.m_tile_end[0];
+      index_type temp1        = m_policy.m_tile_end[1];
+      const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl1 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl0)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl0;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+
+      temp0                   = m_policy.m_tile_end[2];
+      temp1                   = m_policy.m_tile_end[3];
+      const index_type numbl2 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl3 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl2)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id2 =
+          static_cast<index_type>(hipBlockIdx_y) % numbl2;
+      const index_type tile_id3 =
+          static_cast<index_type>(hipBlockIdx_y) / numbl2;
+      const index_type thr_id2 =
+          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[2];
+      const index_type thr_id3 =
+          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[2];
+
+      for (index_type tile_id4 = static_cast<index_type>(hipBlockIdx_z);
+           tile_id4 < m_policy.m_tile_end[4]; tile_id4 += hipGridDim_z) {
+        const index_type offset_4 =
+            tile_id4 * m_policy.m_tile[4] +
+            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(m_policy.m_lower[4]);
+        if (offset_4 < m_policy.m_upper[4] &&
+            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[4]) {
+          for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
+               l += numbl3) {
+            const index_type offset_3 =
+                l * m_policy.m_tile[3] + thr_id3 +
+                static_cast<index_type>(m_policy.m_lower[3]);
+            if (offset_3 < m_policy.m_upper[3] &&
+                thr_id3 < m_policy.m_tile[3]) {
+              for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
+                   k += numbl2) {
+                const index_type offset_2 =
+                    k * m_policy.m_tile[2] + thr_id2 +
+                    static_cast<index_type>(m_policy.m_lower[2]);
+                if (offset_2 < m_policy.m_upper[2] &&
+                    thr_id2 < m_policy.m_tile[2]) {
+                  for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+                       j += numbl1) {
+                    const index_type offset_1 =
+                        j * m_policy.m_tile[1] + thr_id1 +
+                        static_cast<index_type>(m_policy.m_lower[1]);
+                    if (offset_1 < m_policy.m_upper[1] &&
+                        thr_id1 < m_policy.m_tile[1]) {
+                      for (index_type i = tile_id0; i < m_policy.m_tile_end[0];
+                           i += numbl0) {
+                        const index_type offset_0 =
+                            i * m_policy.m_tile[0] + thr_id0 +
+                            static_cast<index_type>(m_policy.m_lower[0]);
+                        if (offset_0 < m_policy.m_upper[0] &&
+                            thr_id0 < m_policy.m_tile[0]) {
+                          m_func(offset_0, offset_1, offset_2, offset_3,
+                                 offset_4);
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    // LR
+    else {
+      index_type temp0        = m_policy.m_tile_end[0];
+      index_type temp1        = m_policy.m_tile_end[1];
+      const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl0 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl1)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl1;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+
+      temp0                   = m_policy.m_tile_end[2];
+      temp1                   = m_policy.m_tile_end[3];
+      const index_type numbl3 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl2 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl3)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id2 =
+          static_cast<index_type>(hipBlockIdx_y) / numbl3;
+      const index_type tile_id3 =
+          static_cast<index_type>(hipBlockIdx_y) % numbl3;
+      const index_type thr_id2 =
+          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[3];
+      const index_type thr_id3 =
+          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[3];
+
+      for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
+        const index_type offset_0 =
+            i * m_policy.m_tile[0] + thr_id0 +
+            static_cast<index_type>(m_policy.m_lower[0]);
+        if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
+          for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+               j += numbl1) {
+            const index_type offset_1 =
+                j * m_policy.m_tile[1] + thr_id1 +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                thr_id1 < m_policy.m_tile[1]) {
+              for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
+                   k += numbl2) {
+                const index_type offset_2 =
+                    k * m_policy.m_tile[2] + thr_id2 +
+                    static_cast<index_type>(m_policy.m_lower[2]);
+                if (offset_2 < m_policy.m_upper[2] &&
+                    thr_id2 < m_policy.m_tile[2]) {
+                  for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
+                       l += numbl3) {
+                    const index_type offset_3 =
+                        l * m_policy.m_tile[3] + thr_id3 +
+                        static_cast<index_type>(m_policy.m_lower[3]);
+                    if (offset_3 < m_policy.m_upper[3] &&
+                        thr_id3 < m_policy.m_tile[3]) {
+                      for (index_type tile_id4 =
+                               static_cast<index_type>(hipBlockIdx_z);
+                           tile_id4 < m_policy.m_tile_end[4];
+                           tile_id4 += hipGridDim_z) {
+                        const index_type offset_4 =
+                            tile_id4 * m_policy.m_tile[4] +
+                            static_cast<index_type>(hipThreadIdx_z) +
+                            static_cast<index_type>(m_policy.m_lower[4]);
+                        if (offset_4 < m_policy.m_upper[4] &&
+                            static_cast<index_type>(hipThreadIdx_z) <
+                                m_policy.m_tile[4]) {
+                          m_func(offset_0, offset_1, offset_2, offset_3,
+                                 offset_4);
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+};
+
+// Specializations for tag type
+template <typename PolicyType, typename Functor, typename Tag>
+struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
+  using index_type = typename PolicyType::index_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_)
+      : m_policy(policy_), m_func(f_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    // LL
+    if (PolicyType::inner_direction == PolicyType::Left) {
+      index_type temp0        = m_policy.m_tile_end[0];
+      index_type temp1        = m_policy.m_tile_end[1];
+      const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl1 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl0)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl0;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+
+      temp0                   = m_policy.m_tile_end[2];
+      temp1                   = m_policy.m_tile_end[3];
+      const index_type numbl2 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl3 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl2)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id2 =
+          static_cast<index_type>(hipBlockIdx_y) % numbl2;
+      const index_type tile_id3 =
+          static_cast<index_type>(hipBlockIdx_y) / numbl2;
+      const index_type thr_id2 =
+          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[2];
+      const index_type thr_id3 =
+          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[2];
+
+      for (index_type tile_id4 = static_cast<index_type>(hipBlockIdx_z);
+           tile_id4 < m_policy.m_tile_end[4]; tile_id4 += hipGridDim_z) {
+        const index_type offset_4 =
+            tile_id4 * m_policy.m_tile[4] +
+            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(m_policy.m_lower[4]);
+        if (offset_4 < m_policy.m_upper[4] &&
+            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[4]) {
+          for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
+               l += numbl3) {
+            const index_type offset_3 =
+                l * m_policy.m_tile[3] + thr_id3 +
+                static_cast<index_type>(m_policy.m_lower[3]);
+            if (offset_3 < m_policy.m_upper[3] &&
+                thr_id3 < m_policy.m_tile[3]) {
+              for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
+                   k += numbl2) {
+                const index_type offset_2 =
+                    k * m_policy.m_tile[2] + thr_id2 +
+                    static_cast<index_type>(m_policy.m_lower[2]);
+                if (offset_2 < m_policy.m_upper[2] &&
+                    thr_id2 < m_policy.m_tile[2]) {
+                  for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+                       j += numbl1) {
+                    const index_type offset_1 =
+                        j * m_policy.m_tile[1] + thr_id1 +
+                        static_cast<index_type>(m_policy.m_lower[1]);
+                    if (offset_1 < m_policy.m_upper[1] &&
+                        thr_id1 < m_policy.m_tile[1]) {
+                      for (index_type i = tile_id0; i < m_policy.m_tile_end[0];
+                           i += numbl0) {
+                        const index_type offset_0 =
+                            i * m_policy.m_tile[0] + thr_id0 +
+                            static_cast<index_type>(m_policy.m_lower[0]);
+                        if (offset_0 < m_policy.m_upper[0] &&
+                            thr_id0 < m_policy.m_tile[0]) {
+                          m_func(Tag(), offset_0, offset_1, offset_2, offset_3,
+                                 offset_4);
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    // LR
+    else {
+      index_type temp0        = m_policy.m_tile_end[0];
+      index_type temp1        = m_policy.m_tile_end[1];
+      const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl0 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl1)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl1;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+
+      temp0                   = m_policy.m_tile_end[2];
+      temp1                   = m_policy.m_tile_end[3];
+      const index_type numbl3 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl2 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl3)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id2 =
+          static_cast<index_type>(hipBlockIdx_y) / numbl3;
+      const index_type tile_id3 =
+          static_cast<index_type>(hipBlockIdx_y) % numbl3;
+      const index_type thr_id2 =
+          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[3];
+      const index_type thr_id3 =
+          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[3];
+
+      for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
+        const index_type offset_0 =
+            i * m_policy.m_tile[0] + thr_id0 +
+            static_cast<index_type>(m_policy.m_lower[0]);
+        if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
+          for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+               j += numbl1) {
+            const index_type offset_1 =
+                j * m_policy.m_tile[1] + thr_id1 +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                thr_id1 < m_policy.m_tile[1]) {
+              for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
+                   k += numbl2) {
+                const index_type offset_2 =
+                    k * m_policy.m_tile[2] + thr_id2 +
+                    static_cast<index_type>(m_policy.m_lower[2]);
+                if (offset_2 < m_policy.m_upper[2] &&
+                    thr_id2 < m_policy.m_tile[2]) {
+                  for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
+                       l += numbl3) {
+                    const index_type offset_3 =
+                        l * m_policy.m_tile[3] + thr_id3 +
+                        static_cast<index_type>(m_policy.m_lower[3]);
+                    if (offset_3 < m_policy.m_upper[3] &&
+                        thr_id3 < m_policy.m_tile[3]) {
+                      for (index_type tile_id4 =
+                               static_cast<index_type>(hipBlockIdx_z);
+                           tile_id4 < m_policy.m_tile_end[4];
+                           tile_id4 += hipGridDim_z) {
+                        const index_type offset_4 =
+                            tile_id4 * m_policy.m_tile[4] +
+                            static_cast<index_type>(hipThreadIdx_z) +
+                            static_cast<index_type>(m_policy.m_lower[4]);
+                        if (offset_4 < m_policy.m_upper[4] &&
+                            static_cast<index_type>(hipThreadIdx_z) <
+                                m_policy.m_tile[4]) {
+                          m_func(Tag(), offset_0, offset_1, offset_2, offset_3,
+                                 offset_4);
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+};
+
+// Rank 6
+// Specializations for void tag type
+template <typename PolicyType, typename Functor>
+struct DeviceIterateTile<6, PolicyType, Functor, void> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& rp_, const Functor& f_)
+      : m_policy(rp_), m_func(f_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    // LL
+    if (PolicyType::inner_direction == PolicyType::Left) {
+      index_type temp0        = m_policy.m_tile_end[0];
+      index_type temp1        = m_policy.m_tile_end[1];
+      const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl1 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl0)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl0;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+
+      temp0                   = m_policy.m_tile_end[2];
+      temp1                   = m_policy.m_tile_end[3];
+      const index_type numbl2 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl3 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl2)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id2 =
+          static_cast<index_type>(hipBlockIdx_y) % numbl2;
+      const index_type tile_id3 =
+          static_cast<index_type>(hipBlockIdx_y) / numbl2;
+      const index_type thr_id2 =
+          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[2];
+      const index_type thr_id3 =
+          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[2];
+
+      temp0                   = m_policy.m_tile_end[4];
+      temp1                   = m_policy.m_tile_end[5];
+      const index_type numbl4 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl5 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl4)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id4 =
+          static_cast<index_type>(hipBlockIdx_z) % numbl4;
+      const index_type tile_id5 =
+          static_cast<index_type>(hipBlockIdx_z) / numbl4;
+      const index_type thr_id4 =
+          static_cast<index_type>(hipThreadIdx_z) % m_policy.m_tile[4];
+      const index_type thr_id5 =
+          static_cast<index_type>(hipThreadIdx_z) / m_policy.m_tile[4];
+
+      for (index_type n = tile_id5; n < m_policy.m_tile_end[5]; n += numbl5) {
+        const index_type offset_5 =
+            n * m_policy.m_tile[5] + thr_id5 +
+            static_cast<index_type>(m_policy.m_lower[5]);
+        if (offset_5 < m_policy.m_upper[5] && thr_id5 < m_policy.m_tile[5]) {
+          for (index_type m = tile_id4; m < m_policy.m_tile_end[4];
+               m += numbl4) {
+            const index_type offset_4 =
+                m * m_policy.m_tile[4] + thr_id4 +
+                static_cast<index_type>(m_policy.m_lower[4]);
+            if (offset_4 < m_policy.m_upper[4] &&
+                thr_id4 < m_policy.m_tile[4]) {
+              for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
+                   l += numbl3) {
+                const index_type offset_3 =
+                    l * m_policy.m_tile[3] + thr_id3 +
+                    static_cast<index_type>(m_policy.m_lower[3]);
+                if (offset_3 < m_policy.m_upper[3] &&
+                    thr_id3 < m_policy.m_tile[3]) {
+                  for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
+                       k += numbl2) {
+                    const index_type offset_2 =
+                        k * m_policy.m_tile[2] + thr_id2 +
+                        static_cast<index_type>(m_policy.m_lower[2]);
+                    if (offset_2 < m_policy.m_upper[2] &&
+                        thr_id2 < m_policy.m_tile[2]) {
+                      for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+                           j += numbl1) {
+                        const index_type offset_1 =
+                            j * m_policy.m_tile[1] + thr_id1 +
+                            static_cast<index_type>(m_policy.m_lower[1]);
+                        if (offset_1 < m_policy.m_upper[1] &&
+                            thr_id1 < m_policy.m_tile[1]) {
+                          for (index_type i = tile_id0;
+                               i < m_policy.m_tile_end[0]; i += numbl0) {
+                            const index_type offset_0 =
+                                i * m_policy.m_tile[0] + thr_id0 +
+                                static_cast<index_type>(m_policy.m_lower[0]);
+                            if (offset_0 < m_policy.m_upper[0] &&
+                                thr_id0 < m_policy.m_tile[0]) {
+                              m_func(offset_0, offset_1, offset_2, offset_3,
+                                     offset_4, offset_5);
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    // LR
+    else {
+      index_type temp0        = m_policy.m_tile_end[0];
+      index_type temp1        = m_policy.m_tile_end[1];
+      const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl0 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl1)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl1;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+
+      temp0                   = m_policy.m_tile_end[2];
+      temp1                   = m_policy.m_tile_end[3];
+      const index_type numbl3 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl2 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl3)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id2 =
+          static_cast<index_type>(hipBlockIdx_y) / numbl3;
+      const index_type tile_id3 =
+          static_cast<index_type>(hipBlockIdx_y) % numbl3;
+      const index_type thr_id2 =
+          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[3];
+      const index_type thr_id3 =
+          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[3];
+
+      temp0                   = m_policy.m_tile_end[4];
+      temp1                   = m_policy.m_tile_end[5];
+      const index_type numbl5 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl4 =
+          (temp0 * temp1 > max_blocks
+               ? index_type(max_blocks / numbl5)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id4 =
+          static_cast<index_type>(hipBlockIdx_z) / numbl5;
+      const index_type tile_id5 =
+          static_cast<index_type>(hipBlockIdx_z) % numbl5;
+      const index_type thr_id4 =
+          static_cast<index_type>(hipThreadIdx_z) / m_policy.m_tile[5];
+      const index_type thr_id5 =
+          static_cast<index_type>(hipThreadIdx_z) % m_policy.m_tile[5];
+
+      for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
+        const index_type offset_0 =
+            i * m_policy.m_tile[0] + thr_id0 +
+            static_cast<index_type>(m_policy.m_lower[0]);
+        if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
+          for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+               j += numbl1) {
+            const index_type offset_1 =
+                j * m_policy.m_tile[1] + thr_id1 +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                thr_id1 < m_policy.m_tile[1]) {
+              for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
+                   k += numbl2) {
+                const index_type offset_2 =
+                    k * m_policy.m_tile[2] + thr_id2 +
+                    static_cast<index_type>(m_policy.m_lower[2]);
+                if (offset_2 < m_policy.m_upper[2] &&
+                    thr_id2 < m_policy.m_tile[2]) {
+                  for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
+                       l += numbl3) {
+                    const index_type offset_3 =
+                        l * m_policy.m_tile[3] + thr_id3 +
+                        static_cast<index_type>(m_policy.m_lower[3]);
+                    if (offset_3 < m_policy.m_upper[3] &&
+                        thr_id3 < m_policy.m_tile[3]) {
+                      for (index_type m = tile_id4; m < m_policy.m_tile_end[4];
+                           m += numbl4) {
+                        const index_type offset_4 =
+                            m * m_policy.m_tile[4] + thr_id4 +
+                            static_cast<index_type>(m_policy.m_lower[4]);
+                        if (offset_4 < m_policy.m_upper[4] &&
+                            thr_id4 < m_policy.m_tile[4]) {
+                          for (index_type n = tile_id5;
+                               n < m_policy.m_tile_end[5]; n += numbl5) {
+                            const index_type offset_5 =
+                                n * m_policy.m_tile[5] + thr_id5 +
+                                static_cast<index_type>(m_policy.m_lower[5]);
+                            if (offset_5 < m_policy.m_upper[5] &&
+                                thr_id5 < m_policy.m_tile[5]) {
+                              m_func(offset_0, offset_1, offset_2, offset_3,
+                                     offset_4, offset_5);
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+};
+
+// Specializations for tag type
+template <typename PolicyType, typename Functor, typename Tag>
+struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
+  using index_type = typename PolicyType::index_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_)
+      : m_policy(policy_), m_func(f_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    // LL
+    if (PolicyType::inner_direction == PolicyType::Left) {
+      index_type temp0        = m_policy.m_tile_end[0];
+      index_type temp1        = m_policy.m_tile_end[1];
+      const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl1 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl0)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl0;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+
+      temp0                   = m_policy.m_tile_end[2];
+      temp1                   = m_policy.m_tile_end[3];
+      const index_type numbl2 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl3 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl2)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id2 =
+          static_cast<index_type>(hipBlockIdx_y) % numbl2;
+      const index_type tile_id3 =
+          static_cast<index_type>(hipBlockIdx_y) / numbl2;
+      const index_type thr_id2 =
+          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[2];
+      const index_type thr_id3 =
+          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[2];
+
+      temp0                   = m_policy.m_tile_end[4];
+      temp1                   = m_policy.m_tile_end[5];
+      const index_type numbl4 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl5 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl4)
+               : (temp1 <= max_blocks ? temp1 : max_blocks));
+
+      const index_type tile_id4 =
+          static_cast<index_type>(hipBlockIdx_z) % numbl4;
+      const index_type tile_id5 =
+          static_cast<index_type>(hipBlockIdx_z) / numbl4;
+      const index_type thr_id4 =
+          static_cast<index_type>(hipThreadIdx_z) % m_policy.m_tile[4];
+      const index_type thr_id5 =
+          static_cast<index_type>(hipThreadIdx_z) / m_policy.m_tile[4];
+
+      for (index_type n = tile_id5; n < m_policy.m_tile_end[5]; n += numbl5) {
+        const index_type offset_5 =
+            n * m_policy.m_tile[5] + thr_id5 +
+            static_cast<index_type>(m_policy.m_lower[5]);
+        if (offset_5 < m_policy.m_upper[5] && thr_id5 < m_policy.m_tile[5]) {
+          for (index_type m = tile_id4; m < m_policy.m_tile_end[4];
+               m += numbl4) {
+            const index_type offset_4 =
+                m * m_policy.m_tile[4] + thr_id4 +
+                static_cast<index_type>(m_policy.m_lower[4]);
+            if (offset_4 < m_policy.m_upper[4] &&
+                thr_id4 < m_policy.m_tile[4]) {
+              for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
+                   l += numbl3) {
+                const index_type offset_3 =
+                    l * m_policy.m_tile[3] + thr_id3 +
+                    static_cast<index_type>(m_policy.m_lower[3]);
+                if (offset_3 < m_policy.m_upper[3] &&
+                    thr_id3 < m_policy.m_tile[3]) {
+                  for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
+                       k += numbl2) {
+                    const index_type offset_2 =
+                        k * m_policy.m_tile[2] + thr_id2 +
+                        static_cast<index_type>(m_policy.m_lower[2]);
+                    if (offset_2 < m_policy.m_upper[2] &&
+                        thr_id2 < m_policy.m_tile[2]) {
+                      for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+                           j += numbl1) {
+                        const index_type offset_1 =
+                            j * m_policy.m_tile[1] + thr_id1 +
+                            static_cast<index_type>(m_policy.m_lower[1]);
+                        if (offset_1 < m_policy.m_upper[1] &&
+                            thr_id1 < m_policy.m_tile[1]) {
+                          for (index_type i = tile_id0;
+                               i < m_policy.m_tile_end[0]; i += numbl0) {
+                            const index_type offset_0 =
+                                i * m_policy.m_tile[0] + thr_id0 +
+                                static_cast<index_type>(m_policy.m_lower[0]);
+                            if (offset_0 < m_policy.m_upper[0] &&
+                                thr_id0 < m_policy.m_tile[0]) {
+                              m_func(Tag(), offset_0, offset_1, offset_2,
+                                     offset_3, offset_4, offset_5);
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    // LR
+    else {
+      index_type temp0        = m_policy.m_tile_end[0];
+      index_type temp1        = m_policy.m_tile_end[1];
+      const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl0 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl1)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id0 =
+          static_cast<index_type>(hipBlockIdx_x) / numbl1;
+      const index_type tile_id1 =
+          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type thr_id0 =
+          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+      const index_type thr_id1 =
+          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+
+      temp0                   = m_policy.m_tile_end[2];
+      temp1                   = m_policy.m_tile_end[3];
+      const index_type numbl3 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl2 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl3)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id2 =
+          static_cast<index_type>(hipBlockIdx_y) / numbl3;
+      const index_type tile_id3 =
+          static_cast<index_type>(hipBlockIdx_y) % numbl3;
+      const index_type thr_id2 =
+          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[3];
+      const index_type thr_id3 =
+          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[3];
+
+      temp0                   = m_policy.m_tile_end[4];
+      temp1                   = m_policy.m_tile_end[5];
+      const index_type numbl5 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type numbl4 =
+          (temp0 * temp1 > max_blocks
+               ? static_cast<index_type>(max_blocks / numbl5)
+               : (temp0 <= max_blocks ? temp0 : max_blocks));
+
+      const index_type tile_id4 =
+          static_cast<index_type>(hipBlockIdx_z) / numbl5;
+      const index_type tile_id5 =
+          static_cast<index_type>(hipBlockIdx_z) % numbl5;
+      const index_type thr_id4 =
+          static_cast<index_type>(hipThreadIdx_z) / m_policy.m_tile[5];
+      const index_type thr_id5 =
+          static_cast<index_type>(hipThreadIdx_z) % m_policy.m_tile[5];
+
+      for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
+        const index_type offset_0 =
+            i * m_policy.m_tile[0] + thr_id0 +
+            static_cast<index_type>(m_policy.m_lower[0]);
+        if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
+          for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
+               j += numbl1) {
+            const index_type offset_1 =
+                j * m_policy.m_tile[1] + thr_id1 +
+                static_cast<index_type>(m_policy.m_lower[1]);
+            if (offset_1 < m_policy.m_upper[1] &&
+                thr_id1 < m_policy.m_tile[1]) {
+              for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
+                   k += numbl2) {
+                const index_type offset_2 =
+                    k * m_policy.m_tile[2] + thr_id2 +
+                    static_cast<index_type>(m_policy.m_lower[2]);
+                if (offset_2 < m_policy.m_upper[2] &&
+                    thr_id2 < m_policy.m_tile[2]) {
+                  for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
+                       l += numbl3) {
+                    const index_type offset_3 =
+                        l * m_policy.m_tile[3] + thr_id3 +
+                        static_cast<index_type>(m_policy.m_lower[3]);
+                    if (offset_3 < m_policy.m_upper[3] &&
+                        thr_id3 < m_policy.m_tile[3]) {
+                      for (index_type m = tile_id4; m < m_policy.m_tile_end[4];
+                           m += numbl4) {
+                        const index_type offset_4 =
+                            m * m_policy.m_tile[4] + thr_id4 +
+                            static_cast<index_type>(m_policy.m_lower[4]);
+                        if (offset_4 < m_policy.m_upper[4] &&
+                            thr_id4 < m_policy.m_tile[4]) {
+                          for (index_type n = tile_id5;
+                               n < m_policy.m_tile_end[5]; n += numbl5) {
+                            const index_type offset_5 =
+                                n * m_policy.m_tile[5] + thr_id5 +
+                                static_cast<index_type>(m_policy.m_lower[5]);
+                            if (offset_5 < m_policy.m_upper[5] &&
+                                thr_id5 < m_policy.m_tile[5]) {
+                              m_func(Tag(), offset_0, offset_1, offset_2,
+                                     offset_3, offset_4, offset_5);
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+};
+
+// ----------------------------------------------------------------------------------
+
+namespace Reduce {
+
+template <typename T>
+using is_void = std::is_same<T, void>;
+
+template <typename T>
+struct is_array_type : std::false_type {
+  using value_type = T;
+};
+
+template <typename T>
+struct is_array_type<T*> : std::true_type {
+  using value_type = T;
+};
+
+template <typename T>
+struct is_array_type<T[]> : std::true_type {
+  using value_type = T;
+};
+
+// ------------------------------------------------------------------ //
+template <int N, typename PolicyType, typename Functor, typename Tag,
+          typename ValueType, typename Enable = void>
+struct DeviceIterateTile;
+
+// ParallelReduce iteration pattern
+// Scalar reductions
+
+// num_blocks = min( num_tiles, max_num_blocks ); //i.e. determined by number of
+// tiles and reduction algorithm constraints extract n-dim tile offsets (i.e.
+// tile's global starting mulit-index) from the tileid = blockid using tile
+// dimensions local indices within a tile extracted from (index_type)threadIdx_x
+// using tile dims, constrained by blocksize combine tile and local id info for
+// multi-dim global ids
+
+// Pattern:
+// Each block+thread is responsible for a tile+local_id combo (additional when
+// striding by num_blocks)
+// 1. create offset arrays
+// 2. loop over number of tiles, striding by griddim (equal to num tiles, or max
+// num blocks)
+// 3. temps set for tile_idx and thrd_idx, which will be modified
+// 4. if LL vs LR:
+//      determine tile starting point offsets (multidim)
+//      determine local index offsets (multidim)
+//      concatentate tile offset + local offset for global multi-dim index
+//    if offset withinin range bounds AND local offset within tile bounds, call
+//    functor
+
+// ValueType = T
+// Rank 2
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename ValueType>
+struct DeviceIterateTile<
+    2, PolicyType, Functor, void, ValueType,
+    typename std::enable_if<!is_array_type<ValueType>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& rp_, const Functor& f_,
+                               ValueType& v_)
+      : m_policy(rp_), m_func(f_), m_v(v_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            // Deduce this blocks tile_id
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_v);
+          }
+        }
+      }
+    }
+
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  ValueType& m_v;
+};
+
+// Specializations for tag type
+template <typename PolicyType, typename Functor, typename Tag,
+          typename ValueType>
+struct DeviceIterateTile<
+    2, PolicyType, Functor, Tag, ValueType,
+    typename std::enable_if<!is_array_type<ValueType>::value &&
+                            !is_void<Tag>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& rp_, const Functor& f_, ValueType& v_)
+      : m_policy(rp_), m_func(f_), m_v(v_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] =
+                (thrd_idx %
+                 m_policy.m_tile[i]);  // Move this to first computation,
+                                       // add to m_offset right away
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  ValueType& m_v;
+};
+
+// Rank 3
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename ValueType>
+struct DeviceIterateTile<
+    3, PolicyType, Functor, void, ValueType,
+    typename std::enable_if<!is_array_type<ValueType>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                               ValueType& v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] =
+                (thrd_idx %
+                 m_policy.m_tile[i]);  // Move this to first computation,
+                                       // add to m_offset right away
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  ValueType& m_v;
+};
+
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename Tag,
+          typename ValueType>
+struct DeviceIterateTile<
+    3, PolicyType, Functor, Tag, ValueType,
+    typename std::enable_if<!is_array_type<ValueType>::value &&
+                            !is_void<Tag>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_, ValueType& v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] =
+                (thrd_idx %
+                 m_policy.m_tile[i]);  // Move this to first computation,
+                                       // add to m_offset right away
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  ValueType& m_v;
+};
+
+// Rank 4
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename ValueType>
+struct DeviceIterateTile<
+    4, PolicyType, Functor, void, ValueType,
+    typename std::enable_if<!is_array_type<ValueType>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                               ValueType& v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  ValueType& m_v;
+};
+
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename Tag,
+          typename ValueType>
+struct DeviceIterateTile<
+    4, PolicyType, Functor, Tag, ValueType,
+    typename std::enable_if<!is_array_type<ValueType>::value &&
+                            !is_void<Tag>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_, ValueType& v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  ValueType& m_v;
+};
+
+// Rank 5
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename ValueType>
+struct DeviceIterateTile<
+    5, PolicyType, Functor, void, ValueType,
+    typename std::enable_if<!is_array_type<ValueType>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                               ValueType& v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  ValueType& m_v;
+};
+
+// Specializations for tag type
+template <typename PolicyType, typename Functor, typename Tag,
+          typename ValueType>
+struct DeviceIterateTile<
+    5, PolicyType, Functor, Tag, ValueType,
+    typename std::enable_if<!is_array_type<ValueType>::value &&
+                            !is_void<Tag>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                               ValueType& v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  ValueType& m_v;
+};
+
+// Rank 6
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename ValueType>
+struct DeviceIterateTile<
+    6, PolicyType, Functor, void, ValueType,
+    typename std::enable_if<!is_array_type<ValueType>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                               ValueType& v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_offset[5], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_offset[5], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  ValueType& m_v;
+};
+
+// Specializations for tag type
+template <typename PolicyType, typename Functor, typename Tag,
+          typename ValueType>
+struct DeviceIterateTile<
+    6, PolicyType, Functor, Tag, ValueType,
+    typename std::enable_if<!is_array_type<ValueType>::value &&
+                            !is_void<Tag>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+
+  __device__ DeviceIterateTile(const PolicyType& rp_, const Functor& f_,
+                               ValueType& v_)
+      : m_policy(rp_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_offset[5], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_offset[5], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  ValueType& m_v;
+};
+
+// ValueType = T[], T*
+// Rank 2
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename ValueType>
+struct DeviceIterateTile<
+    2, PolicyType, Functor, void, ValueType,
+    typename std::enable_if<is_array_type<ValueType>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+  using value_type = typename is_array_type<ValueType>::value_type;
+
+  __device__ DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                               value_type* v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] =
+                (thrd_idx %
+                 m_policy.m_tile[i]);  // Move this to first computation,
+                                       // add to m_offset right away
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  value_type* m_v;
+};
+
+// Specializations for tag type
+template <typename PolicyType, typename Functor, typename Tag,
+          typename ValueType>
+struct DeviceIterateTile<
+    2, PolicyType, Functor, Tag, ValueType,
+    typename std::enable_if<is_array_type<ValueType>::value &&
+                            !is_void<Tag>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+  using value_type = typename is_array_type<ValueType>::value_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& rp_, const Functor& f_, value_type* v_)
+      : m_policy(rp_), m_func(f_), m_v(v_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_v);
+          }
+        }
+      }  // end for loop over num_tiles - product of tiles in each direction
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  value_type* m_v;
+};
+
+// Rank 3
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename ValueType>
+struct DeviceIterateTile<
+    3, PolicyType, Functor, void, ValueType,
+    typename std::enable_if<is_array_type<ValueType>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+  using value_type = typename is_array_type<ValueType>::value_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                    value_type* v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] =
+                (thrd_idx %
+                 m_policy.m_tile[i]);  // Move this to first computation,
+                                       // add to m_offset right away
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] =
+                (thrd_idx %
+                 m_policy.m_tile[i]);  // Move this to first computation,
+                                       // add to m_offset right away
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  value_type* m_v;
+};
+
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename Tag,
+          typename ValueType>
+struct DeviceIterateTile<
+    3, PolicyType, Functor, Tag, ValueType,
+    typename std::enable_if<is_array_type<ValueType>::value &&
+                            !is_void<Tag>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+  using value_type = typename is_array_type<ValueType>::value_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                    value_type* v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  value_type* m_v;
+};
+
+// Rank 4
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename ValueType>
+struct DeviceIterateTile<
+    4, PolicyType, Functor, void, ValueType,
+    typename std::enable_if<is_array_type<ValueType>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+  using value_type = typename is_array_type<ValueType>::value_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                    value_type* v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  value_type* m_v;
+};
+
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename Tag,
+          typename ValueType>
+struct DeviceIterateTile<
+    4, PolicyType, Functor, Tag, ValueType,
+    typename std::enable_if<is_array_type<ValueType>::value &&
+                            !is_void<Tag>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+  using value_type = typename is_array_type<ValueType>::value_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                    value_type* v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  value_type* m_v;
+};
+
+// Rank 5
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename ValueType>
+struct DeviceIterateTile<
+    5, PolicyType, Functor, void, ValueType,
+    typename std::enable_if<is_array_type<ValueType>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+  using value_type = typename is_array_type<ValueType>::value_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                    value_type* v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  value_type* m_v;
+};
+
+// Specializations for tag type
+template <typename PolicyType, typename Functor, typename Tag,
+          typename ValueType>
+struct DeviceIterateTile<
+    5, PolicyType, Functor, Tag, ValueType,
+    typename std::enable_if<is_array_type<ValueType>::value &&
+                            !is_void<Tag>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+  using value_type = typename is_array_type<ValueType>::value_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                    value_type* v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  value_type* m_v;
+};
+
+// Rank 6
+// Specializations for void tag type
+template <typename PolicyType, typename Functor, typename ValueType>
+struct DeviceIterateTile<
+    6, PolicyType, Functor, void, ValueType,
+    typename std::enable_if<is_array_type<ValueType>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+  using value_type = typename is_array_type<ValueType>::value_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                    value_type* v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_offset[5], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_offset[5], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  value_type* m_v;
+};
+
+// Specializations for tag type
+template <typename PolicyType, typename Functor, typename Tag,
+          typename ValueType>
+struct DeviceIterateTile<
+    6, PolicyType, Functor, Tag, ValueType,
+    typename std::enable_if<is_array_type<ValueType>::value &&
+                            !is_void<Tag>::value>::type> {
+  using index_type = typename PolicyType::index_type;
+  using value_type = typename is_array_type<ValueType>::value_type;
+
+  KOKKOS_INLINE_FUNCTION
+  DeviceIterateTile(const PolicyType& policy_, const Functor& f_,
+                    value_type* v_)
+      : m_policy(policy_), m_func(f_), m_v(v_) {}
+
+  static constexpr index_type max_blocks = 65535;
+
+  KOKKOS_INLINE_FUNCTION
+  void exec_range() const {
+    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+      index_type m_offset[PolicyType::rank];  // tile starting global id offset
+      index_type
+          m_local_offset[PolicyType::rank];  // tile starting global id offset
+
+      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
+           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        bool in_bounds      = true;
+
+        // LL
+        if (PolicyType::inner_direction == PolicyType::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_offset[5], m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
+
+            // tile-local indices identified with hipThreadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds &= false;
+            }
+          }
+          if (in_bounds) {
+            m_func(Tag(), m_offset[0], m_offset[1], m_offset[2], m_offset[3],
+                   m_offset[4], m_offset[5], m_v);
+          }
+        }
+      }
+    }
+  }  // end exec_range
+
+ private:
+  const PolicyType& m_policy;
+  const Functor& m_func;
+  value_type* m_v;
+};
+
+}  // namespace Reduce
+}  // namespace Impl
+}  // namespace Kokkos
+#endif
+#endif

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -55,142 +55,124 @@ template <class FunctorType, class... Traits>
 class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
                   Kokkos::Experimental::HIP> {
  public:
-  typedef Kokkos::MDRangePolicy<Traits...> Policy;
+  using Policy = Kokkos::MDRangePolicy<Traits...>;
 
  private:
-  using RP = Policy;
-  typedef typename Policy::array_index_type array_index_type;
-  typedef typename Policy::index_type index_type;
-  typedef typename Policy::launch_bounds LaunchBounds;
+  using array_index_type = typename Policy::array_index_type;
+  using index_type       = typename Policy::index_type;
+  using LaunchBounds     = typename Policy::launch_bounds;
 
   const FunctorType m_functor;
-  const Policy m_rp;
+  const Policy m_policy;
+
+  ParallelFor()        = delete;
+  ParallelFor& operator=(ParallelFor const&) = delete;
 
  public:
   inline __device__ void operator()(void) const {
-    // FIXME to implement
-    //  Kokkos::Impl::Refactor::DeviceIterateTile<Policy::rank, Policy,
-    //  FunctorType,
-    //                                            typename Policy::work_tag>(
-    //      m_rp, m_functor)
-    //      .exec_range();
+    Kokkos::Impl::DeviceIterateTile<Policy::rank, Policy, FunctorType,
+                                    typename Policy::work_tag>(m_policy,
+                                                               m_functor)
+        .exec_range();
   }
 
   inline void execute() const {
-    // FIXME to implement
-    //  if (m_rp.m_num_tiles == 0)
-    //    return;
-    //  const array_index_type maxblocks = static_cast<array_index_type>(
-    //      m_rp.space().impl_internal_space_instance()->m_maxBlock);
-    //  if (RP::rank == 2)
-    //  {
-    //    const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1], 1);
-    //    const dim3 grid(
-    //        std::min((m_rp.m_upper[0] - m_rp.m_lower[0] + block.x - 1) /
-    //        block.x,
-    //                 maxblocks),
-    //        std::min((m_rp.m_upper[1] - m_rp.m_lower[1] + block.y - 1) /
-    //        block.y,
-    //                 maxblocks),
-    //        1);
-    //    Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelFor,
-    //    LaunchBounds>(
-    //        *this, grid, block, 0,
-    //        m_rp.space().impl_internal_space_instance(), false);
-    //  }
-    //  else if (RP::rank == 3)
-    //  {
-    //    const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1], m_rp.m_tile[2]);
-    //    const dim3 grid(
-    //        std::min((m_rp.m_upper[0] - m_rp.m_lower[0] + block.x - 1) /
-    //        block.x,
-    //                 maxblocks),
-    //        std::min((m_rp.m_upper[1] - m_rp.m_lower[1] + block.y - 1) /
-    //        block.y,
-    //                 maxblocks),
-    //        std::min((m_rp.m_upper[2] - m_rp.m_lower[2] + block.z - 1) /
-    //        block.z,
-    //                 maxblocks));
-    //    Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelFor,
-    //    LaunchBounds>(
-    //        *this, grid, block, 0,
-    //        m_rp.space().impl_internal_space_instance(), false);
-    //  }
-    //  else if (RP::rank == 4)
-    //  {
-    //    // id0,id1 encoded within threadIdx.x; id2 to threadIdx.y; id3 to
-    //    // threadIdx.z
-    //    const dim3 block(m_rp.m_tile[0] * m_rp.m_tile[1], m_rp.m_tile[2],
-    //                     m_rp.m_tile[3]);
-    //    const dim3 grid(
-    //        std::min(
-    //            static_cast<index_type>(m_rp.m_tile_end[0] *
-    //            m_rp.m_tile_end[1]), static_cast<index_type>(maxblocks)),
-    //        std::min((m_rp.m_upper[2] - m_rp.m_lower[2] + block.y - 1) /
-    //        block.y,
-    //                 maxblocks),
-    //        std::min((m_rp.m_upper[3] - m_rp.m_lower[3] + block.z - 1) /
-    //        block.z,
-    //                 maxblocks));
-    //    Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelFor,
-    //    LaunchBounds>(
-    //        *this, grid, block, 0,
-    //        m_rp.space().impl_internal_space_instance(), false);
-    //  }
-    //  else if (RP::rank == 5)
-    //  {
-    //    // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4 to
-    //    // threadIdx.z
-    //    const dim3 block(m_rp.m_tile[0] * m_rp.m_tile[1],
-    //                     m_rp.m_tile[2] * m_rp.m_tile[3], m_rp.m_tile[4]);
-    //    const dim3 grid(
-    //        std::min(
-    //            static_cast<index_type>(m_rp.m_tile_end[0] *
-    //            m_rp.m_tile_end[1]), static_cast<index_type>(maxblocks)),
-    //        std::min(
-    //            static_cast<index_type>(m_rp.m_tile_end[2] *
-    //            m_rp.m_tile_end[3]), static_cast<index_type>(maxblocks)),
-    //        std::min((m_rp.m_upper[4] - m_rp.m_lower[4] + block.z - 1) /
-    //        block.z,
-    //                 maxblocks));
-    //    Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelFor,
-    //    LaunchBounds>(
-    //        *this, grid, block, 0,
-    //        m_rp.space().impl_internal_space_instance(), false);
-    //  }
-    //  else if (RP::rank == 6)
-    //  {
-    //    // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4,id5
-    //    to
-    //    // threadIdx.z
-    //    const dim3 block(m_rp.m_tile[0] * m_rp.m_tile[1],
-    //                     m_rp.m_tile[2] * m_rp.m_tile[3],
-    //                     m_rp.m_tile[4] * m_rp.m_tile[5]);
-    //    const dim3 grid(std::min(static_cast<index_type>(m_rp.m_tile_end[0] *
-    //                                                     m_rp.m_tile_end[1]),
-    //                             static_cast<index_type>(maxblocks)),
-    //                    std::min(static_cast<index_type>(m_rp.m_tile_end[2] *
-    //                                                     m_rp.m_tile_end[3]),
-    //                             static_cast<index_type>(maxblocks)),
-    //                    std::min(static_cast<index_type>(m_rp.m_tile_end[4] *
-    //                                                     m_rp.m_tile_end[5]),
-    //                             static_cast<index_type>(maxblocks)));
-    //    Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelFor,
-    //    LaunchBounds>(
-    //        *this, grid, block, 0,
-    //        m_rp.space().impl_internal_space_instance(), false);
-    //  }
-    //  else
-    //  {
-    //    printf("Kokkos::MDRange Error: Exceeded rank bounds with HIP\n");
-    //    Kokkos::abort("Aborting");
-    //  }
+    if (m_policy.m_num_tiles == 0) return;
+    array_index_type const maxblocks = static_cast<array_index_type>(
+        m_policy.space().impl_internal_space_instance()->m_maxBlock);
+    if (Policy::rank == 2) {
+      dim3 const block(m_policy.m_tile[0], m_policy.m_tile[1], 1);
+      dim3 const grid(
+          std::min((m_policy.m_upper[0] - m_policy.m_lower[0] + block.x - 1) /
+                       block.x,
+                   maxblocks),
+          std::min((m_policy.m_upper[1] - m_policy.m_lower[1] + block.y - 1) /
+                       block.y,
+                   maxblocks),
+          1);
+      Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelFor, LaunchBounds>(
+          *this, grid, block, 0,
+          m_policy.space().impl_internal_space_instance(), false);
+    } else if (Policy::rank == 3) {
+      dim3 const block(m_policy.m_tile[0], m_policy.m_tile[1],
+                       m_policy.m_tile[2]);
+      dim3 const grid(
+          std::min((m_policy.m_upper[0] - m_policy.m_lower[0] + block.x - 1) /
+                       block.x,
+                   maxblocks),
+          std::min((m_policy.m_upper[1] - m_policy.m_lower[1] + block.y - 1) /
+                       block.y,
+                   maxblocks),
+          std::min((m_policy.m_upper[2] - m_policy.m_lower[2] + block.z - 1) /
+                       block.z,
+                   maxblocks));
+      Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelFor, LaunchBounds>(
+          *this, grid, block, 0,
+          m_policy.space().impl_internal_space_instance(), false);
+    } else if (Policy::rank == 4) {
+      // id0,id1 encoded within hipThreadIdx_x; id2 to hipThreadIdx_y; id3 to
+      // hipThreadIdx_z
+      dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
+                       m_policy.m_tile[2], m_policy.m_tile[3]);
+      dim3 const grid(
+          std::min(static_cast<index_type>(m_policy.m_tile_end[0] *
+                                           m_policy.m_tile_end[1]),
+                   static_cast<index_type>(maxblocks)),
+          std::min((m_policy.m_upper[2] - m_policy.m_lower[2] + block.y - 1) /
+                       block.y,
+                   maxblocks),
+          std::min((m_policy.m_upper[3] - m_policy.m_lower[3] + block.z - 1) /
+                       block.z,
+                   maxblocks));
+      Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelFor, LaunchBounds>(
+          *this, grid, block, 0,
+          m_policy.space().impl_internal_space_instance(), false);
+    } else if (Policy::rank == 5) {
+      // id0,id1 encoded within hipThreadIdx_x; id2,id3 to hipThreadIdx_y; id4
+      // to hipThreadIdx_z
+      dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
+                       m_policy.m_tile[2] * m_policy.m_tile[3],
+                       m_policy.m_tile[4]);
+      dim3 const grid(
+          std::min(static_cast<index_type>(m_policy.m_tile_end[0] *
+                                           m_policy.m_tile_end[1]),
+                   static_cast<index_type>(maxblocks)),
+          std::min(static_cast<index_type>(m_policy.m_tile_end[2] *
+                                           m_policy.m_tile_end[3]),
+                   static_cast<index_type>(maxblocks)),
+          std::min((m_policy.m_upper[4] - m_policy.m_lower[4] + block.z - 1) /
+                       block.z,
+                   maxblocks));
+      Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelFor, LaunchBounds>(
+          *this, grid, block, 0,
+          m_policy.space().impl_internal_space_instance(), false);
+    } else if (Policy::rank == 6) {
+      // id0,id1 encoded within hipThreadIdx_x; id2,id3 to hipThreadIdx_y;
+      // id4,id5 to hipThreadIdx_z
+      dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
+                       m_policy.m_tile[2] * m_policy.m_tile[3],
+                       m_policy.m_tile[4] * m_policy.m_tile[5]);
+      dim3 const grid(std::min(static_cast<index_type>(m_policy.m_tile_end[0] *
+                                                       m_policy.m_tile_end[1]),
+                               static_cast<index_type>(maxblocks)),
+                      std::min(static_cast<index_type>(m_policy.m_tile_end[2] *
+                                                       m_policy.m_tile_end[3]),
+                               static_cast<index_type>(maxblocks)),
+                      std::min(static_cast<index_type>(m_policy.m_tile_end[4] *
+                                                       m_policy.m_tile_end[5]),
+                               static_cast<index_type>(maxblocks)));
+      Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelFor, LaunchBounds>(
+          *this, grid, block, 0,
+          m_policy.space().impl_internal_space_instance(), false);
+    } else {
+      printf("Kokkos::MDRange Error: Exceeded rank bounds with HIP\n");
+      Kokkos::abort("Aborting");
+    }
 
   }  // end execute
 
-  //  inline
-  ParallelFor(const FunctorType &arg_functor, Policy arg_policy)
-      : m_functor(arg_functor), m_rp(arg_policy) {}
+  ParallelFor(FunctorType const& arg_functor, Policy const& arg_policy)
+      : m_functor(arg_functor), m_policy(arg_policy) {}
 };
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -62,6 +62,10 @@
 #include <ROCm/KokkosExp_ROCm_IterateTile_Refactor.hpp>
 #endif
 
+#if defined(__HIPCC__) && defined(KOKKOS_ENABLE_HIP)
+#include <HIP/KokkosExp_HIP_IterateTile.hpp>
+#endif
+
 namespace Kokkos {
 
 // ------------------------------------------------------------------ //
@@ -78,7 +82,8 @@ enum class Iterate
 template <typename ExecSpace>
 struct default_outer_direction {
   using type = Iterate;
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_ROCM)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_ROCM) || \
+    defined(KOKKOS_ENABLE_HIP)
   static constexpr Iterate value = Iterate::Left;
 #else
   static constexpr Iterate value = Iterate::Right;
@@ -88,7 +93,8 @@ struct default_outer_direction {
 template <typename ExecSpace>
 struct default_inner_direction {
   using type = Iterate;
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_ROCM)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_ROCM) || \
+    defined(KOKKOS_ENABLE_HIP)
   static constexpr Iterate value = Iterate::Left;
 #else
   static constexpr Iterate value = Iterate::Right;
@@ -256,6 +262,10 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
         && !std::is_same<typename traits::execution_space,
                          Kokkos::Experimental::ROCm>::value
 #endif
+#if defined(KOKKOS_ENABLE_HIP)
+        && !std::is_same<typename traits::execution_space,
+                         Kokkos::Experimental::HIP>::value
+#endif
     ) {
       index_type span;
       for (int i = 0; i < rank; ++i) {
@@ -274,7 +284,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
         m_prod_tile_dims *= m_tile[i];
       }
     }
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     else  // Cuda
     {
       index_type span;
@@ -286,15 +296,21 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
         rank_start = rank - 1;
         rank_end   = -1;
       }
+      bool is_cuda_exec_space =
+#if defined(KOKKOS_ENABLE_CUDA)
+          std::is_same<typename traits::execution_space, Kokkos::Cuda>::value;
+#else
+          false;
+#endif
       for (int i = rank_start; i != rank_end; i += increment) {
         span = m_upper[i] - m_lower[i];
         if (m_tile[i] <= 0) {
-          // TODO: determine what is a good default tile size for cuda
+          // TODO: determine what is a good default tile size for cuda and HIP
           // may be rank dependent
           if (((int)inner_direction == (int)Right && (i < rank - 1)) ||
               ((int)inner_direction == (int)Left && (i > 0))) {
             if (m_prod_tile_dims < 256) {
-              m_tile[i] = 2;
+              m_tile[i] = (is_cuda_exec_space) ? 2 : 4;
             } else {
               m_tile[i] = 1;
             }
@@ -310,13 +326,18 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
       if (m_prod_tile_dims >
           1024) {  // Match Cuda restriction for ParallelReduce; 1024,1024,64
                    // max per dim (Kepler), but product num_threads < 1024
-        printf(" Tile dimensions exceed Cuda limits\n");
-        Kokkos::abort(
-            " Cuda ExecSpace Error: MDRange tile dims exceed maximum number of "
-            "threads per block - choose smaller tile dims");
-        // Kokkos::Impl::throw_runtime_exception( " Cuda ExecSpace Error:
-        // MDRange tile dims exceed maximum number of threads per block - choose
-        // smaller tile dims");
+        if (is_cuda_exec_space) {
+          printf(" Tile dimensions exceed Cuda limits\n");
+          Kokkos::abort(
+              " Cuda ExecSpace Error: MDRange tile dims exceed maximum number "
+              "of "
+              "threads per block - choose smaller tile dims");
+        } else {
+          printf(" Tile dimensions exceed HIP limits\n");
+          Kokkos::abort(
+              "HIP ExecSpace Error: MDRange tile dims exceed maximum number of "
+              "threads per block - choose smaller tile dims");
+        }
       }
     }
 #endif
@@ -395,6 +416,10 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 #if defined(KOKKOS_ENABLE_ROCM)
         && !std::is_same<typename traits::execution_space,
                          Kokkos::Experimental::ROCm>::value
+#endif
+#if defined(KOKKOS_ENABLE_HIP)
+        && !std::is_same<typename traits::execution_space,
+                         Kokkos::Experimental::HIP>::value
 #endif
     ) {
       index_type span;
@@ -503,6 +528,51 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
         // Kokkos::Impl::throw_runtime_exception( " Cuda ExecSpace Error:
         // MDRange tile dims exceed maximum number of threads per block - choose
         // smaller tile dims");
+      }
+    }
+#endif
+#if defined(KOKKOS_ENABLE_HIP)
+    else  // HIP
+    {
+      index_type span;
+      int increment  = 1;
+      int rank_start = 0;
+      int rank_end   = rank;
+      if (static_cast<int>(inner_direction) == static_cast<int>(Right)) {
+        increment  = -1;
+        rank_start = rank - 1;
+        rank_end   = -1;
+      }
+      for (int i = rank_start; i != rank_end; i += increment) {
+        span = m_upper[i] - m_lower[i];
+        if (m_tile[i] <= 0) {
+          // TODO: determine what is a good default tile size for HIP
+          // may be rank dependent
+          if ((static_cast<int>(inner_direction) == static_cast<int>(Right) &&
+               (i < rank - 1)) ||
+              (static_cast<int>(inner_direction) == static_cast<int>(Left) &&
+               (i > 0))) {
+            if (m_prod_tile_dims < 256) {
+              m_tile[i] = 2;
+            } else {
+              m_tile[i] = 1;
+            }
+          } else {
+            m_tile[i] = 16;
+          }
+        }
+        m_tile_end[i] =
+            static_cast<index_type>((span + m_tile[i] - 1) / m_tile[i]);
+        m_num_tiles *= m_tile_end[i];
+        m_prod_tile_dims *= m_tile[i];
+      }
+      if (m_prod_tile_dims >
+          1024) {  // Match HIP restriction for ParallelReduce; 1024,1024,1024
+                   // max per dim , but product num_threads < 1024
+        printf(" Tile dimensions exceed HIP limits\n");
+        Kokkos::abort(
+            "HIP ExecSpace Error: MDRange tile dims exceed maximum number of "
+            "threads per block - choose smaller tile dims");
       }
     }
 #endif

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -158,7 +158,7 @@ struct Array {
     return &m_internal_implementation_private_member_data[0];
   }
 
-#ifdef KOKKOS_IMPL_ROCM_CLANG_WORKAROUND
+#ifdef KOKKOS_IMPL_HIP_CLANG_WORKAROUND
   // Do not default unless move and move-assignment are also defined
   KOKKOS_INLINE_FUNCTION
   ~Array()            = default;

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -195,6 +195,8 @@
 
 #if defined(KOKKOS_ENABLE_HIP)
 
+#define KOKKOS_IMPL_HIP_CLANG_WORKAROUND
+
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -271,6 +271,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_HIP), 1)
 	OBJ_HIP += TestHIP_Init.o
 	OBJ_HIP += TestHIP_Reducers_a.o TestHIP_Reducers_b.o TestHIP_Reducers_c.o TestHIP_Reducers_d.o
 	OBJ_HIP += TestHIP_Reductions.o
+	OBJ_HIP += TestHIP_MDRange_a.o TestHIP_MDRange_b.o TestHIP_MDRange_c.o TestHIP_MDRange_d.o TestHIP_MDRange_e.o
 
 	TARGETS += KokkosCore_UnitTest_HIP
 

--- a/core/unit_test/hip/TestHIP_MDRange_a.cpp
+++ b/core/unit_test/hip/TestHIP_MDRange_a.cpp
@@ -1,0 +1,46 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestMDRange_a.hpp>

--- a/core/unit_test/hip/TestHIP_MDRange_b.cpp
+++ b/core/unit_test/hip/TestHIP_MDRange_b.cpp
@@ -1,0 +1,46 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestMDRange_b.hpp>

--- a/core/unit_test/hip/TestHIP_MDRange_c.cpp
+++ b/core/unit_test/hip/TestHIP_MDRange_c.cpp
@@ -1,0 +1,46 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestMDRange_c.hpp>

--- a/core/unit_test/hip/TestHIP_MDRange_d.cpp
+++ b/core/unit_test/hip/TestHIP_MDRange_d.cpp
@@ -1,0 +1,46 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestMDRange_d.hpp>

--- a/core/unit_test/hip/TestHIP_MDRange_e.cpp
+++ b/core/unit_test/hip/TestHIP_MDRange_e.cpp
@@ -1,0 +1,46 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestMDRange_e.hpp>


### PR DESCRIPTION
This enables `parallel_for` and `parallel_reduce` for`MDRange`. It passes all the `Test_MDRange`. Like usual it is a giant PR but it is copied from the CUDA and ROCm backends. There was no need for any workaround this time.